### PR TITLE
added html file for canada page and added correct copyright to homepage

### DIFF
--- a/canada.html
+++ b/canada.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Document</title>
+</head>
+<body>
+    <header>
+        <img src="./images/HelloWorldLogo.png" alt="logo">
+        <div class="headerContainer">
+            <h1 class="countryName">Canada</h1>
+            <nav><a href="./index.html">Home</a><a href="./australia.html">Australia</a><a href="./canada.html">Canada</a><a href="./jamaica.html">Jamaica</a><a href="./japan.html">Japan</a><nav></nav>
+        </div>
+    </header>
+    <img class="canadaImage" src="./images/HelloWorldCanada.png" alt="canadaImage">
+    <article class="contentContainer">
+        <section class="contentContainer__listOfCities">
+            <ul>
+                <li>Toronto</li>
+                <li>Vancouver</li>
+                <li>Montreal</li>
+            </ul>
+        </section>
+        <section class="contentContainer__listOfLandmarks">
+            <ul>
+                <li>Baniff National Park</li>
+                <li>CN Tower</li>
+                <li>Stanley Park</li>
+            </ul>
+        </section>
+        <section class="contentContainer__listOfCitizens">
+            <ul>
+                <li>Jim Carrey</li>
+                <li>Keanu Reeves</li>
+                <li>Pamela Anderson</li>
+            </ul>
+        </section>
+    </article>
+    <footer>&copy;2021 Fancakes Travel Agency</footer>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -32,7 +32,7 @@
         </section>
     </article>
     <footer>
-        &copy;
+        &copy;2021 Fancakes Travel Agency
     </footer>
     
 </body>

--- a/styles/main.css
+++ b/styles/main.css
@@ -1,0 +1,5 @@
+@import "australia.css";
+@import "canada.css";
+@import "homepage.css";
+@import "jamaica.css";
+@import "japan.css";


### PR DESCRIPTION
Should see a page for canada now as well as copyright 2021 fancakes travel agency in footer of index page now.
git fetch --all
git checkout lw-html-for canada-page
serve